### PR TITLE
Add "scoped" attribute to the <style> tag , prevents its style from affecting other elements on the page

### DIFF
--- a/src/components/s-md-toolbar-left.vue
+++ b/src/components/s-md-toolbar-left.vue
@@ -175,7 +175,7 @@ export default {
     }
 }
 </script>
-<style>
+<style scoped>
 
 .mu-item-wrapper .mu-item {
     padding: 0px 16px;

--- a/src/mavon-editor.vue
+++ b/src/mavon-editor.vue
@@ -550,7 +550,7 @@
     @import "lib/css/scroll.styl"
     @import "lib/css/mavon-editor.styl"
 </style>
-<style lang="css">
+<style lang="css" scoped>
 .auto-textarea-wrapper {
     height: 100%;
 }


### PR DESCRIPTION
### Add "scoped" attribute to the <style> tag , prevents its style from affecting other elements on the page
I also use the [muse-ui](https://github.com/museui/muse-ui)  UI framework to build my website.
I found that the style sheet in `src/components/s-md-toolbar-left.vue`  changed the style of the [Drawer](http://www.muse-ui.org/#/drawer) component on the page.
So I added [scoped-css-features](https://vue-loader.vuejs.org/en/features/scoped-css.html)  to avoid this problem

### 给 <style> 标签添加了 `scoped` 属性 , 防止其样式影响页面上的其他元素
我也在使用 [muse-ui](https://github.com/museui/muse-ui) 这个 UI 框架构建页面 . 
我发现 `src/components/s-md-toolbar-left.vue`  中的样式表会改变页面内  [Drawer](http://www.muse-ui.org/#/drawer) 组件 `.mu-item-wrapper .mu-item` 的样式 . 
添加了 [scoped-css-features](https://vue-loader.vuejs.org/en/features/scoped-css.html) 来避免这个问题
