### PR TITLE
修复动态修改default_open无效问题

### DIFF
--- a/src/mavon-editor.vue
+++ b/src/mavon-editor.vue
@@ -533,7 +533,7 @@
                 if (this.subfield && !default_open_) {
                     default_open_ = 'preview';
                 }
-                return default_open_ === 'preview' ? true : false;
+                this.s_preview_switch = default_open_ === 'preview' ? true : false;
             }
         },
         components: {


### PR DESCRIPTION
通过设置`default_open`值，无法切换编辑和预览窗口，watch 监听存在错误。 