### PR TITLE
while pasting image at macOS/chrome, the filename is pasted parallel along with the pasting process, which leads to an unexpected string appears in the editor

### DIFF
--- a/src/lib/util.js
+++ b/src/lib/util.js
@@ -39,3 +39,15 @@ export function p_urlParse() {
   return obj;
 };
 
+export function stopEvent(e) {
+  if (!e) {
+    return;
+  }
+  if (e.preventDefault) {
+    e.preventDefault();
+  }
+  if (e.stopPropagation) {
+    e.stopPropagation();
+  }
+};
+

--- a/src/mavon-editor.vue
+++ b/src/mavon-editor.vue
@@ -94,7 +94,7 @@
         loadScript,
         ImagePreviewListener
     } from './lib/core/extra-function.js'
-    import {p_ObjectCopy_DEEP} from './lib/util.js'
+    import {p_ObjectCopy_DEEP, stopEvent} from './lib/util.js'
     import {toolbar_left_click, toolbar_left_addlink} from './lib/toolbar_left_click.js'
     import {toolbar_right_click} from './lib/toolbar_right_click.js'
     import {CONFIG} from './lib/config.js'
@@ -347,6 +347,9 @@
                         }
                     }
                     if (item && item.kind === 'file') {
+                        // prevent filename being pasted parallel along
+                        // with the image pasting process
+                        stopEvent($e)
                         var oFile = item.getAsFile();
                         this.$refs.toolbar_left.$imgFilesAdd([oFile,]);
                     }


### PR DESCRIPTION
事情是这样的，我在mac上，用chrome测试粘贴图片的时候，发现这样一个问题：

![2018-04-08 2 56 22](https://user-images.githubusercontent.com/1059956/38464349-02a9e14a-3b3f-11e8-922e-5fd040cf50b6.png)

如上图，你可以看到，我选中的部分是“真正的文件名”，因为没有阻止系统默认的粘贴行为，所以“它”也被粘贴下来，而这个是我们不需要的。