### PR TITLE
Fixed typos in pt-BR and popup size

### DIFF
--- a/src/components/s-md-toolbar-left.vue
+++ b/src/components/s-md-toolbar-left.vue
@@ -250,7 +250,7 @@
             background #fff
             top 34px
             left -20px
-            width 120px
+            min-width 120px
             z-index 1600
             box-shadow: 0 0px 4px rgba(0, 0, 0, .156863), 0 0px 4px rgba(0, 0, 0, .227451)
         .dropdown-item

--- a/src/lib/lang/pt-BR/words_pt-BR.json
+++ b/src/lib/lang/pt-BR/words_pt-BR.json
@@ -1,5 +1,5 @@
 {
-	"start_editor": "Cimeçar edição...",
+	"start_editor": "Começar edição...",
 	"navigation_title": "Navegação",
 	"tl_bold": "Negrito",
 	"tl_italic": "Itálico",

--- a/src/lib/lang/pt-BR/words_pt-BR.json
+++ b/src/lib/lang/pt-BR/words_pt-BR.json
@@ -1,5 +1,5 @@
 {
-	"start_editor": "Cemeçar edição...",
+	"start_editor": "Cimeçar edição...",
 	"navigation_title": "Navegação",
 	"tl_bold": "Negrito",
 	"tl_italic": "Itálico",
@@ -20,8 +20,8 @@
 	"tl_redo": "Refazer",
 	"tl_trash": "Lixo",
 	"tl_save": "Salvar",
-	"tl_navigation_on": "Mostrar Navigation",
-	"tl_navigation_off": "Esconder Navigation",
+	"tl_navigation_on": "Mostrar Navegação",
+	"tl_navigation_off": "Esconder Navegação",
 	"tl_preview": "Preview",
 	"tl_aligncenter": "Alinhar no centro",
 	"tl_alignleft": "Alinhar à esquerda",
@@ -40,6 +40,6 @@
 	"tl_popup_link_title": "Adicionar Link",
 	"tl_popup_link_text": "Link Texto",
 	"tl_popup_link_addr": "Link Endereço",
-	"tl_popup_link_sure": "Claro",
+	"tl_popup_link_sure": "Confirmar",
 	"tl_popup_link_cancel": "Cancelar"
 }


### PR DESCRIPTION
Found some typos in my translation.
Also changed the image upload popup to min-width: 120px instead of width, text was overflowing in pt-BR. With this it should be as before for other languages but also fit for pt-BR