### PR TITLE
增加自定义 Markdown-It API

### DIFF
--- a/doc/cn/markdown.md
+++ b/doc/cn/markdown.md
@@ -1,5 +1,15 @@
 ## Markdown-It
 
+### 自定义 markdown-it
+
+有时候，你并不需要内置的默认 markdown-it，因为内置对象为了兼容所有功能和渲染，配置了大量插件！如果你只需要少量插件或者直观的
+设置更多插件。你可以使用此 API:
+
+```vue
+const markdownIt = () => {}; // 你的自定义过程
+<mavon-editor markdown-it="markdownIt" />
+```
+
 ### 获取mavonEditor中的markdown-it对象
 
 #### 方法1 通过全局引入的mavonEditor获取
@@ -14,8 +24,6 @@
 ```javascript
   import {mavonEditor} from 'mavon-editor'
   mavonEditor.getMarkdownIt()
-  或者
-  mavonEditor.mixins[0].data().markdownIt
 ```
 
 #### 方法3 通过mavonEditor的实例获取
@@ -23,6 +31,14 @@
    <mavonEditor ref=md></mavonEditor>
    ...
    this.refs.md.markdownIt
+```
+
+#### 方法4
+
+> 此方法只能获取内置默认 markdown-it 对象，如果你需要实例对象请参考上述三个方法，如果你自定义了 markdown-it 对象，你自己可以自定义任何方法获取。
+
+```js
+import { defaultMarkdownIt } from 'mavon-editor';
 ```
 
 ### 使用markdown-it对象

--- a/src/index.js
+++ b/src/index.js
@@ -7,10 +7,12 @@
  * mavonEditor
  * @author hinesboy
  */
-const mavonEditor = require('./mavon-editor.vue');
+const MavonEditor = require('./mavon-editor.vue');
+const { defaultMarkdownIt } = require('./lib/mixins/markdown');
 const VueMavonEditor = {
     markdownIt: mavonEditor.mixins[0].data().markdownIt,
-    mavonEditor: mavonEditor,
+    MavonEditor,
+    defaultMarkdownIt,
     install: function(Vue) {
         Vue.component('mavon-editor', mavonEditor);
     }

--- a/src/lib/mixins/markdown.js
+++ b/src/lib/mixins/markdown.js
@@ -86,10 +86,12 @@ markdown.use(mihe, hljs_opts)
     .use(taskLists)
     .use(toc)
 
+export const defaultMarkdownIt = markdown;
 export default {
-    data() {
-        return {
-            markdownIt: markdown
+    props: {
+        markdownIt: {
+            type: Object,
+            default: () => defaultMarkdownIt
         }
     },
     mounted() {
@@ -101,7 +103,7 @@ export default {
             var $vm = this;
             missLangs = {};
             needLangs = [];
-            var res = markdown.render(src);
+            var res = $vm.markdownIt.render(src);
             if (this.ishljs) {
                 if (needLangs.length > 0) {
                     $vm.$_render(src, func, res);
@@ -117,7 +119,7 @@ export default {
                 loadScript(url, function() {
                     deal = deal + 1;
                     if (deal === needLangs.length) {
-                        res = markdown.render(src);
+                        res = $vm.markdownIt.render(src);
                         func(res);
                     }
                 })

--- a/src/mavon-editor.vue
+++ b/src/mavon-editor.vue
@@ -306,7 +306,7 @@
             document.body.removeChild(this.$refs.help);
         },
         getMarkdownIt() {
-            return this.mixins[0].data().markdownIt
+            return this.markdownIt;
         },
         methods: {
             loadExternalLink(name, type, callback) {


### PR DESCRIPTION
允许自定义 markdown-it 对象：

```vue
<mavon-editor markdown-it="customMarkdownItObject" />
```