### PR TITLE
fix hljslang target

### DIFF
--- a/src/lib/mixins/markdown.js
+++ b/src/lib/mixins/markdown.js
@@ -63,7 +63,7 @@ var hljs_opts = {
     langCheck: function(lang) {
         if (lang && hljsLangs[lang] && !missLangs[lang]) {
             missLangs[lang] = 1;
-            needLangs.push(lang)
+            needLangs.push(hljsLangs[lang])
         }
     }
 };


### PR DESCRIPTION
# summary

When I wrote code language that is alias for another language in markdown, I caught a 404 link for hightlight.js.

demo: https://jsfiddle.net/qf7gLw3a/745/ (see F12 developper tools)

# markdown
```
    load `https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.12.0/languages/v.min.js` ← 404

    ```v
    // wrong loading!! ("v" is an alias for "verilog")
    ```

    ----

    load `https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.12.0/languages/verilog.min.js` ← 200

    ```verilog
    // good loading
    ```
```   

# actual request

![default](https://user-images.githubusercontent.com/38449628/44826507-4af61a00-ac4a-11e8-81a0-fa18a6692ca2.png)
