### PR TITLE
add box-sizing border-box

### DIFF
--- a/src/lib/css/mavon-editor.styl
+++ b/src/lib/css/mavon-editor.styl
@@ -44,6 +44,7 @@
           border-left 1px solid #e5e5e5
           margin 0 6px 0 4px
         .op-icon
+          box-sizing border-box
           display inline-block
           cursor pointer
           height 28px


### PR DESCRIPTION
如果使用`externalLink=false`的話，header和圖片按鈕會位移（如圖）
因為github-markdown.css剛好設定`box-sizing border-box`才正常
因此把`box-sizing border-box`加入mavonEditor的css檔案

![](https://screenshotscdn.firefoxusercontent.com/images/91f8049e-41cf-49a5-aed0-657057d2b18e.png)