### PR TITLE
Fix typo in English Readme Dcocument 

### DIFF
--- a/README-EN.md
+++ b/README-EN.md
@@ -112,7 +112,7 @@ toolbars: {
       trash: true,
       save: true,
       /* 1.4.2 */
-      navigation: true，
+      navigation: true,
       /* 2.1.8 */
       alignleft: true,
       aligncenter: true,


### PR DESCRIPTION
## Fixed typo in `README-EN.md`.
Changed from fullwidth forms `，` to halfwidth forms `,` .

## Error Message
```
Syntax Error: Unexpected character '，'
```


