### PR TITLE
Update README

### DIFF
--- a/README-EN.md
+++ b/README-EN.md
@@ -17,8 +17,13 @@
 ## Use Setup
 
 ### Install mavon-editor
+#### For `npm` user
 ```
-$ npm install mavon-editor --save
+$ npm install mavon-editor
+```
+#### For `yarn` user
+```
+$ yarn add mavon-editor
 ```
 
 ### Use

--- a/README-EN.md
+++ b/README-EN.md
@@ -118,6 +118,7 @@ export default {
 | toolbarsFlag | Boolean     |   true       | Show toolbars |
 | navigation | Boolean |    false    |  Show navigation  |
 | shortCut | Boolean |    true    |  shortcut switch  |
+| autofocus | Boolean |    true     | Autofocus on textbox |
 | ishljs       | Boolean |     true     | highlight code switch |
 | imageFilter | Function |     null     | Image file filter Function, params is a `File Object`, you should return `Boolean` about the test result |
 | imageClick | function |     null     |  Image Click Function |

--- a/README.md
+++ b/README.md
@@ -25,8 +25,14 @@
 
 ### Install mavon-editor (安装)
 
+#### For `npm` user
 ```
-$ npm install mavon-editor --save
+$ npm install mavon-editor
+```
+
+#### For `yarn` user
+```
+$ yarn add mavon-editor
 ```
 
 ### Use (如何引入)


### PR DESCRIPTION
Issue
-------------
- Missed "autofocus" props on README-EN.md
- There was no information of `yarn` command
- `npm` is `--save` by default from v5.0.0 [(npm blog)](https://blog.npmjs.org/post/161081169345/v500)

Resolve
------------
- add "autofocus" props on the reference's table on README-EN.md
- add the way to install by `yarn` command
- deleted `--save` option from `npm install` command