### PR TITLE
mavonEditor - Cross-Site Scripting - Fix:

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,8 @@
   "homepage": "https://github.com/hinesboy/mavonEditor#readme",
   "dependencies": {
     "highlight.js": "^9.11.0",
-    "highlight.js-async-webpack": "^1.0.4"
+    "highlight.js-async-webpack": "^1.0.4",
+    "xss": "^1.0.6"
   },
   "devDependencies": {
     "auto-textarea": "^1.4.0",

--- a/src/mavon-editor.vue
+++ b/src/mavon-editor.vue
@@ -93,6 +93,7 @@ import {autoTextarea} from 'auto-textarea'
 import {keydownListen} from './lib/core/keydown-listen.js'
 import hljsCss from './lib/core/hljs/lang.hljs.css.js'
 import hljsLangs from './lib/core/hljs/lang.hljs.js'
+const xss = require('xss');
 import {
     fullscreenchange,
    /* windowResize, */
@@ -659,6 +660,9 @@ export default {
             this.iRender();
         },
         value: function (val, oldVal) {
+            // Escaping all XSS characters
+            val = xss(val);
+
             if (val !== this.d_value) {
                 this.d_value = val
             }


### PR DESCRIPTION
https://github.com/Asjidkalam fixed the vulnerability associated with Cross-Site Scripting.
This fix is being submitted on behalf of https://github.com/Asjidkalam - they have been awarded $25 for fixing the vulnerability through the huntr bug bounty program.
Think you could fix a vulnerability like this - get involved (https://huntr.dev).
Q | A
Version Affected | ALL
Bug Fix | YES
Further References | https://github.com/418sec/mavonEditor/pull/1
Related Issue | https://github.com/hinesboy/mavonEditor/issues/472

Original Comments:

Bug fix:
Sanitized the input value on the textarea of the vNoteEdit panel using the xss module, so that it escapes all the inputs resulting in an XSS.

The XSS mitigation is implemented inside the watch: { value: function (val, oldVal) }, which passes the val variable through the xss() and return the escaped output to the d_value variable.

Files changed:

package.json
mavon-editor.vue