### PR TITLE
添加了一个在编辑器外渲染markdown的例子

### DIFF
--- a/doc/cn/markdown.md
+++ b/doc/cn/markdown.md
@@ -35,3 +35,36 @@
 ```
 
 > [更多设置参考markdown-it...](https://github.com/markdown-it/markdown-it)
+
+### 简单示例
+
+> 注意：`class="markdown-body"` 是必要的，否则CSS样式会于预览的不一样
+
+```html
+<template>
+  <div>
+    <span class="markdown-body" v-html="rawHtml"></span>
+  </div>
+</template>
+
+<script>
+import { mavonEditor } from 'mavon-editor';
+
+export default {
+  name: 'Example',
+  data() {
+    return {
+      rawHtml: '',
+    };
+  },
+  props: {
+    markdown: String,
+  },
+  watch: {
+    markdown() {
+      this.rawHtml = mavonEditor.mixins[0].data().markdownIt.render(this.markdown);
+    },
+  },
+};
+</script>
+```

--- a/doc/cn/markdown.md
+++ b/doc/cn/markdown.md
@@ -49,6 +49,7 @@
 
 <script>
 import { mavonEditor } from 'mavon-editor';
+import "mavon-editor/dist/css/index.css";
 
 export default {
   name: 'Example',
@@ -60,11 +61,11 @@ export default {
   props: {
     markdown: String,
   },
-  watch: {
-    markdown() {
-      this.rawHtml = mavonEditor.mixins[0].data().markdownIt.render(this.markdown);
-    },
-  },
+  computed: {
+    rawHtml: function() {
+      return mavonEditor.mixins[0].data().markdownIt.render(this.markdown);
+    }
+  },
 };
 </script>
 ```

--- a/doc/en/markdown.md
+++ b/doc/en/markdown.md
@@ -49,6 +49,7 @@
 
 <script>
 import { mavonEditor } from 'mavon-editor';
+import "mavon-editor/dist/css/index.css";
 
 export default {
   name: 'Example',
@@ -60,11 +61,11 @@ export default {
   props: {
     markdown: String,
   },
-  watch: {
-    markdown() {
-      this.rawHtml = mavonEditor.mixins[0].data().markdownIt.render(this.markdown);
-    },
-  },
+  computed: {
+    rawHtml: function() {
+      return mavonEditor.mixins[0].data().markdownIt.render(this.markdown);
+    }
+  },
 };
 </script>
 ```

--- a/doc/en/markdown.md
+++ b/doc/en/markdown.md
@@ -35,3 +35,36 @@
 ```
 
 > [markdown-it API](https://github.com/markdown-it/markdown-it)
+
+### Simple example
+
+> Notice：`class="markdown-body"` is necessary, or the CSS style will be different from the preview
+
+```html
+<template>
+  <div>
+    <span class="markdown-body" v-html="rawHtml"></span>
+  </div>
+</template>
+
+<script>
+import { mavonEditor } from 'mavon-editor';
+
+export default {
+  name: 'Example',
+  data() {
+    return {
+      rawHtml: '',
+    };
+  },
+  props: {
+    markdown: String,
+  },
+  watch: {
+    markdown() {
+      this.rawHtml = mavonEditor.mixins[0].data().markdownIt.render(this.markdown);
+    },
+  },
+};
+</script>
+```


### PR DESCRIPTION
编辑器外渲染出来的内容和预览的内容css样式不同，是由于编辑器中导入的css样式只作用于`.markdown-body`的后代，因此写了个简单的例子说明。#69 #399 都提到了类似的问题。