### PR TITLE
fix issue #649

### DIFF
--- a/src/lib/core/extra-function.js
+++ b/src/lib/core/extra-function.js
@@ -381,7 +381,7 @@ export function loadScript(src, callback) {
 }
 
 // <link href="https://cdn.bootcss.com/highlight.js/9.12.0/styles/agate.min.css" rel="stylesheet">
-export function loadLink(src, callback) {
+export function loadLink(src, callback, id) {
     if (!(typeof callback === 'function')) {
         callback = function() {};
     }
@@ -390,10 +390,20 @@ export function loadLink(src, callback) {
         callback();
         return;
     }
+
+    if(id){
+        var styles = document.querySelectorAll("link#" + id);
+        if(styles.length){
+            styles[0].href = src;
+            return;
+        }
+    }
+
     var link = document.createElement('link');
     var head = document.getElementsByTagName('head')[0];
     link.rel = 'stylesheet';
     link.href = src;
+    id && (link['id'] = id);
     if (link.addEventListener) {
         link.addEventListener('load', function () {
             callback();

--- a/src/mavon-editor.vue
+++ b/src/mavon-editor.vue
@@ -636,7 +636,7 @@ export default {
                 url = this.p_external_link.hljs_css('github')
             }
             if (url.length > 0) {
-                loadLink(url)
+                loadLink(url,null,"md-code-style");
             } else {
                 console.warn('hljs color scheme', val, 'do not exist, hljs color scheme will not change');
             }


### PR DESCRIPTION
fix issue #649
问题产生原因：
当切换主题时，会动态加载cdn文件，后加载的样式文件会覆盖掉前面的样式，通过这种方式来达到主题的切换，而已经加载过的cdn文件是不会再加载，所以会出现往回切换不生效问题
修复方案：
通过修改路径的方式，每次只保留一个cdn样式文件