### PR TITLE
fix issue#658,重构插入代码块逻辑

### DIFF
--- a/src/lib/toolbar_left_click.js
+++ b/src/lib/toolbar_left_click.js
@@ -54,6 +54,11 @@ function $toolbar_left_ul_click($vm) {
 function $toolbar_left_remove_line_click($vm) {
     $vm.removeLine()
 }
+
+function $toolbar_left_codeBlock_click($vm){
+    $vm.insertCodeBlock();
+}
+
 // 直接添加链接
 export const toolbar_left_addlink = (type, text, link, $vm) => {
     let insert_text = {
@@ -150,11 +155,6 @@ export const toolbar_left_click = (_type, $vm) => {
              subfix: ')',
              str: $vm.d_words.tl_image
          },
-         'code': {
-             prefix: '```\n',
-             subfix: '\n\n```\n',
-             str: 'language'
-         },
          'table': {
              prefix: '',
              subfix: '',
@@ -188,7 +188,8 @@ export const toolbar_left_click = (_type, $vm) => {
          'save': $toolbar_left_save_click,
          'ol': $toolbar_left_ol_click,
          'ul': $toolbar_left_ul_click,
-         'removeLine': $toolbar_left_remove_line_click
+         'removeLine': $toolbar_left_remove_line_click,
+         'code': $toolbar_left_codeBlock_click
      };
      if (_other_left_click.hasOwnProperty(_type)) {
          _other_left_click[_type]($vm);

--- a/src/mavon-editor.vue
+++ b/src/mavon-editor.vue
@@ -106,6 +106,7 @@ import {
     insertUl,
     insertEnter,
     removeLine,
+    insertCodeBlock,
     loadLink,
     loadScript,
     ImagePreviewListener
@@ -592,9 +593,12 @@ export default {
         unInsertTab() {
             unInsertTab(this, this.tabSize)
         },
+        insertCodeBlock() {
+            insertCodeBlock(this);
+        },
         insertEnter(event) {
             insertEnter(this, event)
-        },
+        },        
         saveHistory() {
             this.d_history.splice(this.d_history_index + 1, this.d_history.length)
             this.d_history.push(this.d_value)


### PR DESCRIPTION
fix issue #658 #632

修改后的场景为：
1. 未选中任何文本状态，点击插入代码按钮，插入如下格式，并且选中`language`：
<pre>
```language

```
</pre>
2. 选中文本状态，点击插入代码按钮，插入如下格式，并且保持选中的文本被选择：
<pre>
```
选择的文本
```
</pre>