### PR TITLE
When user set externalLink attribute,cause style error of code tag

### DIFF
--- a/src/mavon-editor.vue
+++ b/src/mavon-editor.vue
@@ -374,7 +374,11 @@ export default {
                 'js': loadScript
             };
             if (_obj.hasOwnProperty(type)) {
-                _obj[type](this.p_external_link[name](), callback);
+                let id = null
+                if(name === 'markdown_css'){
+                    id = 'md-code-style'
+                }
+                _obj[type](this.p_external_link[name](), callback, id);
             }
         },
         initExternalFuc() {


### PR DESCRIPTION
When user set externalLink attribute,cause style error of code tag, because link tag of github-mardown-css have not id attribute
```vue
<mavon-editor ... :externalLink="externalLink"/>
export default {
  data: function () {
    return {
      externalLink: {
        hljs_css: function(css) {
          return 'https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.12.0/styles/' + css + '.min.css';
        },
      }
    }
  },
...
}
```